### PR TITLE
Splitting linting from unit tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Converts between Arabic numerals and Japanese numerals (it is called 漢数字).",
   "main": "index.js",
   "scripts": {
-    "test": "eslint src/**/*.js test/**/*.js && mocha test/index.js"
+    "test": "npm run test:lint && npm run test:unit",
+    "test:lint": "eslint src/**/*.js test/**/*.js",
+    "test:unit": "mocha test/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running test during developing it was a bit of a bother to run lint every time. This PR splits linting and unit tests in order to be able to run `npm run test:unit` for just the unit tests. Please close if this is a bad idea 😅